### PR TITLE
[FLAMBE-24]ユーザごとのタスク数一覧表示で未完了タスクが存在しないユーザが取得できない不具合の修正等

### DIFF
--- a/app/server/repositories/task_repository.py
+++ b/app/server/repositories/task_repository.py
@@ -26,6 +26,12 @@ def find_by_status_not_done(db: Session) -> List[Task]:
 def find_by_statuses_order_by_status_asc_and_priority_desc(
     filtering_statuses: List[Status], db: Session
 ) -> List[Task]:
+    """
+    フィルタ対象のステータスに一致したタスクを取得し、
+    ・ステータスの昇順（TODO-DOING-DONE）
+    ・優先度の降順（HIGH-MEDIUM-LOW）
+    で並び替えて返却する。
+    """
     return (
         db.query(Task)
         .filter(Task.status.in_(filtering_statuses))
@@ -37,6 +43,12 @@ def find_by_statuses_order_by_status_asc_and_priority_desc(
 def find_by_user_id_and_status_order_by_status_asc_and_priority_desc(
     user_id: int, filtering_statuses: List[Status], db: Session
 ) -> List[Task]:
+    """
+    フィルタ対象のステータスに一致しかつ指定されたユーザがアサインされているタスクを取得し、
+    ・ステータスの昇順（TODO-DOING-DONE）
+    ・優先度の降順（HIGH-MEDIUM-LOW）
+    で並び替えて返却する。
+    """
     return (
         db.query(Task)
         .outerjoin(TaskAssignment)
@@ -49,6 +61,12 @@ def find_by_user_id_and_status_order_by_status_asc_and_priority_desc(
 def find_by_statuses_and_without_assignees_order_by_status_asc_and_priority_desc(
     filtering_statuses: List[Status], db: Session
 ) -> List[Task]:
+    """
+    フィルタ対象のステータスに一致しかつアサインされたユーザが存在しないタスクを取得し、
+    ・ステータスの昇順（TODO-DOING-DONE）
+    ・優先度の降順（HIGH-MEDIUM-LOW）
+    で並び替えて返却する。
+    """
     # アサイン0のタスクIDを抽出
     task_ids_without_assignees = [
         result.id

--- a/app/server/repositories/user_repository.py
+++ b/app/server/repositories/user_repository.py
@@ -43,7 +43,7 @@ def get_users_with_doing_task_count_group_by_priority(
 ]:
     users_with_doing_task_count_by_priority = (
         db.query(
-            User,
+            User.id.label("user_id"),
             Task.priority,
             func.count(TaskAssignment.user_id).label("doing_task_count"),
         )
@@ -58,8 +58,7 @@ def get_users_with_doing_task_count_group_by_priority(
     return list(
         map(
             lambda result: {
-                "user_id": result.User.id,
-                "user": result.User,
+                "user_id": result.user_id,
                 "priority": result.priority,
                 "doing_task_count": result.doing_task_count,
             },

--- a/app/server/repositories/user_repository.py
+++ b/app/server/repositories/user_repository.py
@@ -72,7 +72,7 @@ def get_users_with_done_task_count_order_by_done_task_count(
 ) -> List[TypedDict("UserWithDoneTaskCount", {"user": User, "done_task_count": int})]:
     users_with_count_of_done_tasks = (
         db.query(
-            User,
+            User.id.label("user_id"),
             func.count(TaskAssignment.user_id).label("done_task_count"),
         )
         .join(TaskAssignment)
@@ -86,7 +86,7 @@ def get_users_with_done_task_count_order_by_done_task_count(
     return list(
         map(
             lambda result: {
-                "user": result.User,
+                "user_id": result.user_id,
                 "done_task_count": result.done_task_count,
             },
             users_with_count_of_done_tasks,

--- a/app/server/repositories/user_repository.py
+++ b/app/server/repositories/user_repository.py
@@ -33,7 +33,7 @@ def delete(db: Session, deleted_user: User) -> None:
     db.delete(deleted_user)
 
 
-def get_users_with_doing_task_count_group_by_priority(
+def get_user_ids_with_doing_task_count_group_by_priority(
     db: Session,
 ) -> List[
     TypedDict(
@@ -41,6 +41,9 @@ def get_users_with_doing_task_count_group_by_priority(
         {"user_id": int, "user": User, "priority": Priority, "doing_task_count": int},
     )
 ]:
+    """
+    未完了タスクが存在するユーザのIDと、各未完了タスクの数を優先度別に取得して返却する。
+    """
     users_with_doing_task_count_by_priority = (
         db.query(
             User.id.label("user_id"),
@@ -67,9 +70,12 @@ def get_users_with_doing_task_count_group_by_priority(
     )
 
 
-def get_users_with_done_task_count_order_by_done_task_count(
+def get_user_ids_with_done_task_count_order_by_done_task_count(
     db: Session,
 ) -> List[TypedDict("UserWithDoneTaskCount", {"user": User, "done_task_count": int})]:
+    """
+    完了タスクが存在するユーザのIDと、完了タスク数を取得して返却する。
+    """
     users_with_count_of_done_tasks = (
         db.query(
             User.id.label("user_id"),

--- a/app/server/services/user_service.py
+++ b/app/server/services/user_service.py
@@ -19,15 +19,17 @@ def get_incomplete_tasks(db: Session, user_id: int) -> List[Task]:
 
 
 def get_doing_task_data_of_all_users(db: Session) -> List[dict]:
+    """
+    全ユーザと、それぞれの未完了タスク数を優先度別で集計したデータを返却する。
+    """
+    users = get_all(db=db)
     users_with_doing_task_count_by_priority = (
-        user_repository.get_users_with_doing_task_count_group_by_priority(db=db)
+        user_repository.get_user_ids_with_doing_task_count_group_by_priority(db=db)
     )
-    users = get_all(db)
 
     results_by_users = {}
     for user in users:
         results_by_users[user.id] = []
-
     for result in users_with_doing_task_count_by_priority:
         results_by_users[result["user_id"]].append(result)
 

--- a/app/server/services/user_service.py
+++ b/app/server/services/user_service.py
@@ -22,23 +22,14 @@ def get_doing_task_data_of_all_users(db: Session) -> List[dict]:
     users_with_doing_task_count_by_priority = (
         user_repository.get_users_with_doing_task_count_group_by_priority(db=db)
     )
-    users = list(
-        set(
-            map(
-                lambda user_with_doing_task_count_by_priority: user_with_doing_task_count_by_priority[
-                    "user"
-                ],
-                users_with_doing_task_count_by_priority,
-            )
-        )
-    )
+    users = get_all(db)
 
     results_by_users = {}
     for user in users:
         results_by_users[user.id] = []
 
     for result in users_with_doing_task_count_by_priority:
-        results_by_users[result["user"].id].append(result)
+        results_by_users[result["user_id"]].append(result)
 
     user_with_doing_task_data_list = []
     for user in users:


### PR DESCRIPTION
fix: リポジトリ・サービスをそれぞれ修正
fix:ユーザごとの完了タスク数ランキング表示においても完了タスクが存在しないユーザは取得されない不具合が発生していたので同様に修正
refactor: コメントを追加、メソッド名を修正