### PR TITLE
[FLAMBE-25]エラーハンドリングの修正

### DIFF
--- a/app/server/exceptions/application_exception.py
+++ b/app/server/exceptions/application_exception.py
@@ -10,10 +10,8 @@ class ApplicationException(HTTPException):
         self, error: Type[BaseMessage], status_code: int = default_status_code
     ) -> None:
         self.status_code = status_code
-        self.detail = [
-            {
-                "error_code": str(error()),
-                "error_msg": error.text,
-            }
-        ]
+        self.detail = {
+            "error_code": str(error()),
+            "error_msg": error.text,
+        }
         super().__init__(self.status_code, self.detail)

--- a/app/server/exceptions/system_exception.py
+++ b/app/server/exceptions/system_exception.py
@@ -8,10 +8,10 @@ class InternalServerException(HTTPException):
         self.exc = e
         self.stack_trace = traceback.format_exc()
         self.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-        self.detail = [
-            {
+        self.detail = {
+            "detail": {
                 "error_code": str(ErrorMessages.InternalServerError()),
                 "error_msg": ErrorMessages.InternalServerError().text,
             }
-        ]
+        }
         super().__init__(self.status_code, self.detail)

--- a/app/server/main.py
+++ b/app/server/main.py
@@ -6,7 +6,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi_pagination import add_pagination
 from controllers.user_controller import router as user_router
 from controllers.task_controller import router as task_router
+from exceptions import ApplicationException
 from exceptions.system_exception import InternalServerException
+from starlette.requests import Request
+
 
 router = APIRouter()
 router.include_router(user_router, prefix="/users", tags=["users"])
@@ -17,6 +20,39 @@ app = FastAPI()
 app.include_router(router)
 
 origins = ["http://localhost:9000"]
+add_pagination(app)
+
+
+# cf. https://github.com/tiangolo/fastapi/issues/775#issuecomment-592946834
+# noinspection PyBroadException
+async def catch_exceptions_middleware(request: Request, call_next):
+    try:
+        return await call_next(request)
+    except Exception as exc:
+        exception = InternalServerException(exc)
+        return JSONResponse(status_code=exception.status_code, content=exception.detail)
+
+
+app.middleware("http")(catch_exceptions_middleware)
+
+
+# バリデーションエラーのハンドリング
+# 1つ目のエラーのみ返却
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return JSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content=jsonable_encoder(
+            {
+                "detail": {
+                    "error_code": "ValidationError",
+                    "error_msg": exc.errors()[0]["msg"],
+                }
+            }
+        ),
+    )
+
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
@@ -24,22 +60,3 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-add_pagination(app)
-
-
-@app.exception_handler(Exception)
-async def exception_handler(request, exc):
-    exception = InternalServerException(exc)
-    return JSONResponse(status_code=exception.status_code, content=exception.detail)
-
-
-# バリデーションエラーのハンドリング
-# 1つ目のエラーのみ返却
-@app.exception_handler(RequestValidationError)
-async def validation_exception_handler(request, exc: RequestValidationError):
-    return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        content=jsonable_encoder(
-            {"error_code": "ValidationError", "error_msg": exc.errors()[0]["msg"]}
-        ),
-    )

--- a/app/web-client/src/api/ApiInvoker.ts
+++ b/app/web-client/src/api/ApiInvoker.ts
@@ -179,15 +179,24 @@ class AxiosFactory {
 
   // エラーメッセージのみ、FastAPIでキャメルケースで取り扱うベストプラクティスが不明なため暫定的にスネークケースを許容
   private handleError = (e: AxiosError): void => {
-    const response = e.response?.data;
-    const code = response.error_code ? response.error_code : "unknown";
-    const message = response.error_msg
-      ? response.error_msg
-      : "unknown error occurred";
-    Notification.error({
-      title: `Error: ${code}`,
-      message: message,
-    });
+    const errorResponse = e.response?.data?.detail;
+    if (errorResponse) {
+      const code = errorResponse.error_code
+        ? errorResponse.error_code
+        : "unknown";
+      const message = errorResponse.error_msg
+        ? errorResponse.error_msg
+        : "unknown error occurred";
+      Notification.error({
+        title: `Error: ${code}`,
+        message: message,
+      });
+    } else {
+      Notification.error({
+        title: "Error: unknown",
+        message: "unknown error occurred",
+      });
+    }
   };
 
   // eslint-disable-next-line


### PR DESCRIPTION
fix: システムエラーの場合CORSヘッダが外れてた件に対応
fix: システムエラー、バリデーションエラー、アプリケーションエラーの形式を統一
fix: クライアント側のエラーハンドラを修正